### PR TITLE
Integrate pre-trained LSTM model for market analysis

### DIFF
--- a/comandos.md
+++ b/comandos.md
@@ -14,12 +14,50 @@ models/
 └── market_analysis/
     ├── train_market_model.py         # Treinamento do modelo
     ├── model_market.pkl              # Modelo treinado (output)
-    ├── market_dataset.py             # Carregamento e rotulagem do dataset
+    ├── market_dataset.py             # Carregamento e rotulagem do dataset (Random Forest)
+    ├── lstm_market_dataset.py        # Carregamento e preparação de sequências para LSTM
+    ├── train_lstm_market_model.py    # Treinamento ou carregamento de modelo LSTM
     └── evaluate_market_model.py      # Métricas de validação (F1, confusion, etc.)
 
-🧪 Como rodar:
+🧪 Como rodar (Modelo RandomForest Padrão):
 
 python models/market_analysis/train_market_model.py
+
+Esse comando irá:
+Treinar um Random Forest com os dados preparados (de `market_dataset.py`).
+Imprimir métricas e salvar o modelo em `.pkl`.
+
+🧠 Como usar um Modelo LSTM Pré-Treinado para Análise de Mercado:
+
+1.  **Coloque seu modelo LSTM e scaler nos locais corretos:**
+    *   Modelo LSTM (ex: `.h5`): `models/market_analysis/model/lstm_market_model.h5`
+    *   Scaler (ex: `MinMaxScaler` salvo com `joblib` como `.pkl`): `models/market_analysis/model/lstm_scaler.pkl`
+
+2.  **Atualize a configuração `config/settings.yaml`:**
+    ```yaml
+    model_paths:
+      # Comente ou remova a linha do market_analysis RandomForest
+      # market_analysis: "models/market_analysis/model/model_market.pkl"
+
+      # Adicione os caminhos para o seu modelo LSTM e scaler
+      lstm_market_model: "models/market_analysis/model/lstm_market_model.h5"
+      lstm_market_scaler: "models/market_analysis/model/lstm_scaler.pkl"
+
+      # ... outros modelos de risco e execução ...
+
+    # (Opcional) Configure os parâmetros do LSTM Wrapper
+    lstm_wrapper_params:
+      timesteps: 20  # Ajuste para o número de timesteps que seu LSTM espera
+      # expected_features: ['open', 'high', 'low', 'close', ...] # Descomente e liste se for diferente do default no wrapper
+    ```
+
+3.  **Execute o bot:**
+    O `core/logic.py` irá carregar automaticamente o `LSTMModelWrapper` com base nessas configurações.
+
+4.  **(Opcional) Treinar/Re-treinar um modelo LSTM usando os scripts fornecidos:**
+    *   Execute `python models/market_analysis/train_lstm_market_model.py`.
+    *   Você pode ajustar `TRAIN_NEW = True` no script para treinar um novo modelo ou `TRAIN_NEW = False` para tentar carregar um modelo existente (definido por `MODEL_SAVE_PATH` no script).
+    *   O script `lstm_market_dataset.py` é usado por `train_lstm_market_model.py` para preparar os dados.
 
 Esse comando irá:
 

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -11,7 +11,9 @@ general:
   broker: MT5
 
 model_paths:
-  market_analysis: models/market_analysis/model/model_market.pkl
+  # market_analysis: models/market_analysis/model/model_market.pkl # Comentado para usar LSTM
+  lstm_market_model: "models/market_analysis/model/lstm_market_model.h5"
+  lstm_market_scaler: "models/market_analysis/model/lstm_scaler.pkl"
   risk_action: models/risk_management/model/risk_action_model.pkl
   risk_level: models/risk_management/model/risk_level_model.pkl
   position_size: models/risk_management/model/position_size_model.pkl
@@ -19,6 +21,14 @@ model_paths:
   take_profit: models/risk_management/model/take_profit_model.pkl
   strategy_exec: models/strategy_execution/model/exec_model.pkl
   exec_labels: models/strategy_execution/model/exec_label_map.pkl
+
+# (Opcional) Parâmetros para o LSTMModelWrapper
+# Se não definidos aqui, o wrapper usará seus valores default.
+lstm_wrapper_params:
+  timesteps: 20  # Deve corresponder ao treinamento do LSTM
+  # expected_features: null # Se null, o wrapper usa sua lista default.
+                            # Caso contrário, forneça a lista exata de features que o LSTM espera, na ordem correta.
+                            # Exemplo: ['open', 'high', 'low', 'close', 'tick_volume', 'ema_20', ...]
 
 trading:
   initial_capital: 10000

--- a/exemplo_de_uso.py
+++ b/exemplo_de_uso.py
@@ -1,19 +1,118 @@
 from core.logic import run_autonomous_decision
+import numpy as np
+import time # Para simular um pequeno atraso
 
-market = {
-    "open": 26000, "high": 26100, "low": 25900, "close": 26050, "volume": 1200,
-    "ema_20": 25980, "ema_50": 25800, "macd": 0.002, "rsi": 65,
-    "stoch_k": 80, "atr": 0.015
-}
+# Lista de features esperada pelo LSTMWrapper (default) e pelo core/logic para o mercado
+# Ajuste esta lista se 'expected_features' no seu wrapper ou config for diferente.
+EXPECTED_LSTM_FEATURES = [
+    'open', 'high', 'low', 'close', 'tick_volume',
+    'ema_20', 'ema_50', 'macd', 'rsi', 'stoch_k', 'atr',
+    'obv', 'volume_sma_20', 'volatility_stop', 'volatility_score',
+    'spread_pct' # Adicionado spread_pct que é esperado
+]
 
-state = {
+def generate_dummy_market_data(base_price=26000):
+    """Gera dados de mercado dummy com todas as features esperadas."""
+    data = {
+        "open": base_price + np.random.uniform(-50, 50),
+        "high": base_price + np.random.uniform(0, 100),
+        "low": base_price - np.random.uniform(0, 100),
+        "close": base_price + np.random.uniform(-50, 50),
+        "tick_volume": np.random.randint(500, 2000),
+        "ema_20": base_price + np.random.uniform(-30, 30),
+        "ema_50": base_price + np.random.uniform(-60, 60),
+        "macd": np.random.uniform(-0.005, 0.005),
+        "rsi": np.random.uniform(30, 70),
+        "stoch_k": np.random.uniform(20, 80),
+        "atr": np.random.uniform(0.01, 0.03),
+        "obv": np.random.randint(10000, 50000),
+        "volume_sma_20": np.random.randint(700, 1500),
+        "volatility_stop": base_price - np.random.uniform(50,100), # Exemplo
+        "volatility_score": np.random.uniform(0.001, 0.005),      # Exemplo
+        "spread_pct": np.random.uniform(0.00005, 0.0002)        # Exemplo spread_pct
+    }
+    # Garante que high é o mais alto e low o mais baixo
+    data["high"] = max(data["high"], data["open"], data["close"])
+    data["low"] = min(data["low"], data["open"], data["close"])
+
+    # Adicionar quaisquer features faltantes da lista EXPECTED_LSTM_FEATURES com valor default
+    for feat in EXPECTED_LSTM_FEATURES:
+        if feat not in data:
+            data[feat] = 0.0 # Ou um valor default mais apropriado
+    return data
+
+# Estado inicial do trader
+current_state = {
     "capital": 10000,
-    "in_position": 0,
-    "drawdown": 0.02,
-    "time_in_trade": 0,
-    "recent_losses": 1,
-    "profit_pct": 0.0
+    "in_position": 0,      # 0 = não, 1 = sim (ou poderia ser -1 para short, 1 para long)
+    "drawdown": 0.0,
+    "time_in_trade": 0,    # Em número de velas/períodos
+    "recent_losses": 0,
+    "profit_pct": 0.0,
+    "symbol": "EURUSD_TEST", # Importante para o LSTMWrapper gerenciar históricos
+    "time_since_last_trade": 0 # Adicionado para o modelo de execução
 }
 
-decision = run_autonomous_decision(market, state)
-print(decision)
+# Simular várias iterações para popular o histórico do LSTM
+# O número de iterações deve ser pelo menos 'timesteps' (default 20) + algumas extras
+num_iterations = 25
+timesteps_lstm = 20 # Assumindo o default do wrapper e config
+
+print(f"Simulando {num_iterations} iterações para o símbolo: {current_state['symbol']}")
+print("Certifique-se de que o modelo LSTM e o scaler estão nos caminhos corretos especificados em config/settings.yaml")
+print("Caminhos esperados (default):")
+print("  Modelo: models/market_analysis/model/lstm_market_model.h5")
+print("  Scaler: models/market_analysis/model/lstm_scaler.pkl")
+print("-" * 30)
+
+for i in range(num_iterations):
+    print(f"\n--- Iteração {i + 1}/{num_iterations} ---")
+
+    # Gerar novos dados de mercado para esta iteração
+    # Passar o 'symbol' também no market se o wrapper o utilizar, mas 'state' é mais comum
+    market_data = generate_dummy_market_data(base_price=26000 + i*10)
+    market_data["symbol"] = current_state["symbol"] # Adiciona símbolo aos dados de mercado também
+
+    print(f"Dados de Mercado (vela {i+1}): close={market_data['close']:.2f}, rsi={market_data['rsi']:.2f}")
+
+    # Chamar a lógica de decisão
+    # O wrapper LSTM dentro de run_autonomous_decision usará o 'symbol' do 'current_state'
+    # para buscar/atualizar o histórico de dados correto.
+    decision_output = run_autonomous_decision(market_data, current_state)
+
+    print(f"Decisão: {decision_output.get('final_decision', 'N/A')}")
+    print(f"  Sinal LSTM: {decision_output.get('signal', 'N/A')}, Confiança LSTM: {decision_output.get('confidence', 0.0):.4f}")
+    print(f"  Tamanho Posição: {decision_output.get('position_size', 'N/A')}")
+
+    # Atualizar o estado (simulação básica)
+    if current_state["in_position"]:
+        current_state["time_in_trade"] += 1
+        current_state["profit_pct"] += np.random.uniform(-0.005, 0.005) # Simula variação de lucro
+    else:
+        current_state["time_in_trade"] = 0
+        current_state["time_since_last_trade"] +=1
+
+    if decision_output.get('final_decision') == 'buy' and not current_state["in_position"]:
+        current_state["in_position"] = 1
+        current_state["profit_pct"] = 0.0
+        current_state["time_since_last_trade"] = 0
+        print("  AÇÃO: Entrou em Compra (simulado)")
+    elif decision_output.get('final_decision') == 'sell' and current_state["in_position"]:
+        current_state["in_position"] = 0
+        print(f"  AÇÃO: Saiu da Posição (simulado) com lucro/perda: {current_state['profit_pct']:.4f}")
+        current_state["profit_pct"] = 0.0 # Reset profit_pct ao sair
+
+    # Adiciona um pequeno delay para não sobrecarregar o console e simular tempo real
+    # time.sleep(0.1)
+
+    if i < timesteps_lstm -1 : # O wrapper retorna 0,0 antes de ter dados suficientes
+        if decision_output.get('signal', 'N/A') != 0 or decision_output.get('confidence', 0.0) != 0.0:
+             print(f"⚠️ AVISO: Wrapper LSTM retornou sinal/confiança não nulos ANTES de ter {timesteps_lstm} timesteps. Verifique a lógica do wrapper.")
+    elif i == timesteps_lstm -1 :
+        print(f"🎉 Histórico LSTM para '{current_state['symbol']}' deve estar completo agora ({timesteps_lstm} amostras). Próximas predições usarão o modelo.")
+
+
+print("-" * 30)
+print("Simulação de exemplo concluída.")
+print("Verifique se os sinais e confianças do LSTM parecem razoáveis após as primeiras ~20 iterações.")
+print("Se ocorrerem erros, verifique os logs e os caminhos dos arquivos do modelo/scaler.")


### PR DESCRIPTION
- Added LSTMModelWrapper to load and manage LSTM model and scaler.
- Updated core/logic.py to use the LSTM wrapper for market predictions.
- Modified config/settings.yaml to include paths for LSTM model/scaler and wrapper parameters.
- Added optional scripts for LSTM dataset preparation (lstm_market_dataset.py) and training/loading (train_lstm_market_model.py).
- Updated exemplo_de_uso.py for better testing of LSTM integration with sequential data.
- Updated comandos.md documentation for LSTM usage.